### PR TITLE
Limit testr concurrency to 4

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -23,6 +23,6 @@ ${tempest_dir}/tools/configure-tempest-directory
 tools/config_tempest.py --deployer-input ~/tempest-deployer-input.conf --debug --create identity.uri $OS_AUTH_URL identity.admin_password $OS_PASSWORD object-storage-feature-enabled.discoverability False
 
 [ -d .testrepository ] || testr init
-testr run --subunit --parallel '.*smoke.*' |subunit2junitxml --output-to=../result.xml
+testr run --subunit --parallel --concurrency=4 '.*smoke.*' |subunit2junitxml --output-to=../result.xml
 echo 'done'
 exit 0


### PR DESCRIPTION
Too much concurrent tests are known to produce race conditions errors, trying to reduce the concurrency to try and limit these false errors.